### PR TITLE
chore(goreleaser): make release.prerelease true

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -10,3 +10,5 @@ builds:
   - linux
   goarch:
   - amd64
+release:
+  prerelease: true


### PR DESCRIPTION
After we create a release we update release manually, so until the
update finishes the release should be prerelease.